### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,8 @@ jobs:
   update-homebrew:
     runs-on: macos-latest
     needs: build-and-release
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout homebrew-tap repo


### PR DESCRIPTION
Potential fix for [https://github.com/mani3/dotprint/security/code-scanning/1](https://github.com/mani3/dotprint/security/code-scanning/1)

To fix the problem, you should add an explicit `permissions` block to the `update-homebrew` job. Review what this job needs: it checks out and pushes to a different repository using a custom secret token (`HOMEBREW_TAP_TOKEN`), not `GITHUB_TOKEN`, and does not interact with issues, pull requests, or the main repo's contents via API. The safest minimal permission is `contents: read`, which allows the job to read public repository contents if needed but not write or perform any mutation actions. Add this block under the `update-homebrew` job definition (`permissions:\n  contents: read` under line 57 or with the same indentation as `runs-on`).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
